### PR TITLE
Updated entrypoint to use /bin/sh

### DIFF
--- a/add-static-route-daemonset.yaml
+++ b/add-static-route-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
         - name: add-static-route
           image: ibmcase/kubectl
           imagePullPolicy: Always
-          command: [ "/bin/bash", "-c" ]
+          command: [ "/bin/sh", "-c" ]
           args:
           - >
               _gateway=`ip route get 10.0.0.0/8 | sed 's/.*via \(.*\) dev.*/\1/'`;


### PR DESCRIPTION
Looks like image base has been changed to busybox and it doesn't have /bin/bash. So it is failing. 
Here is the details :

## before fix 
#### Create daemonset
```
$ kubectl create -f add-static-route-daemonset.yaml
daemonset "add-static-route" created

$ kubectl get pods
NAME                     READY     STATUS             RESTARTS   AGE
add-static-route-9hjj5   0/1       CrashLoopBackOff   4          2m
add-static-route-m2zld   0/1       CrashLoopBackOff   4          2m
add-static-route-ncnnc   0/1       CrashLoopBackOff   4          2m
```

#### Describe Pod
```
$ kubectl describe pod add-static-route-9hjj5
Name:           add-static-route-9hjj5
Namespace:      default
Node:           xx.xx.xx.xx/xx.xx.xx.xx
Start Time:     Mon, 09 Jul 2018 17:07:18 +0530
Labels:         controller-revision-hash=112367853
                name=add-static-route
                pod-template-generation=1
Annotations:    kubernetes.io/psp=******
Status:         Running
IP:             xx.xx.xx.xx
Controlled By:  DaemonSet/add-static-route
Containers:
  add-static-route:
    Container ID:  docker://b0b76ea255e4af0db29cd5f5bfcc194a36820c3a57a4ef6a6d05ed420e6ddc16
    Image:         ibmcase/kubectl
    Image ID:      docker-pullable://ibmcase/kubectl@sha256:edcff83cbd9b495bfe177ac87efe8033cde7dd681c50064c9b33a21019281d21
    Port:          <none>
    Command:
      /bin/bash
      -c
    Args:
      _gateway=`ip route get 10.0.0.0/8 | sed 's/.*via \(.*\) dev.*/\1/'`; touch routes_${_lastVersion}.txt; while true; do
  _currVersion=`kubectl get configmap static-routes -o go-template --template '{{.metadata.resourceVersion}}'`
  if [ "${_lastVersion}" == "${_currVersion}" ]; then
    _lastVersion=${_currVersion};
    sleep 5;
    continue;
  fi;
  echo "Change detected to configmap (lastVersion=${_lastVersion}, currVersion=${_currVersion})!";
  kubectl get configmap static-routes -o go-template --template '{{.data.routes}}' | jq -r 'join("\n")' | sort | uniq > routes_${_currVersion}.txt;
  for _route in `comm -23 routes_${_lastVersion}.txt routes_${_currVersion}.txt`; do
    [ ! -z "`ip route show | grep ${_route} | grep ${_gateway}`" ] || continue;
    echo "Deleting ${_route} via ${_gateway} ...";
    ip route del ${_route} via ${_gateway};
  done;
  for _route in `comm -1 routes_${_lastVersion}.txt routes_${_currVersion}.txt | awk '{print $1;}'`; do
    [ -z "`ip route show | grep ${_route} | grep ${_gateway}`" ] || continue;
    echo "Adding ${_route} via ${_gateway} ...";
    ip route add ${_route} via ${_gateway};
  done;

  rm -f routes_${_lastVersion}.txt;
  _lastVersion=${_currVersion};
done

    State:       Waiting
      Reason:    CrashLoopBackOff
    Last State:  Terminated
      Reason:    ContainerCannotRun
      Message:   oci runtime error: container_linux.go:262: starting container process caused "exec: \"/bin/bash\": stat /bin/bash: no such file or directory"

      Exit Code:    127
      Started:      Mon, 09 Jul 2018 17:13:10 +0530
      Finished:     Mon, 09 Jul 2018 17:13:10 +0530
    Ready:          False
    Restart Count:  6
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from add-static-routes-token-fg2ww (ro)
Conditions:
  Type           Status
  Initialized    True 
  Ready          False 
  PodScheduled   True 
Volumes:
  add-static-routes-token-fg2ww:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  add-static-routes-token-fg2ww
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/disk-pressure:NoSchedule
                 node.kubernetes.io/memory-pressure:NoSchedule
                 node.kubernetes.io/not-ready:NoExecute
                 node.kubernetes.io/unreachable:NoExecute
Events:
  Type     Reason                 Age               From                 Message
  ----     ------                 ----              ----                 -------
  Normal   SuccessfulMountVolume  7m                kubelet, xx.xx.xx.xx  MountVolume.SetUp succeeded for volume "add-static-routes-token-fg2ww"
  Normal   Created                6m (x4 over 7m)   kubelet, xx.xx.xx.xx  Created container
  Warning  Failed                 6m (x4 over 7m)   kubelet, xx.xx.xx.xx  Error: failed to start container "add-static-route": Error response from daemon: oci runtime error: container_linux.go:262: starting container process caused "exec: \"/bin/bash\": stat /bin/bash: no such file or directory"
  Normal   Pulling                5m (x5 over 7m)   kubelet, xx.xx.xx.xx  pulling image "ibmcase/kubectl"
  Normal   Pulled                 5m (x5 over 7m)   kubelet, xx.xx.xx.xx  Successfully pulled image "ibmcase/kubectl"
  Warning  BackOff                2m (x22 over 6m)  kubelet, xx.xx.xx.xx  Back-off restarting failed container
```


## After fix :

#### Create daemonset
```
$ kubectl get pods
NAME                     READY     STATUS    RESTARTS   AGE
add-static-route-gk2cv   1/1       Running   0          5s
add-static-route-gvbnt   1/1       Running   0          5s
add-static-route-hzc7p   1/1       Running   0          5s
```

#### Describe Pod
```
$ kubectl describe pod add-static-route-gk2cv
Name:           add-static-route-gk2cv
Namespace:      default
Node:           xx.xx.xx.xx/xx.xx.xx.xx
Start Time:     Mon, 09 Jul 2018 17:22:33 +0530
Labels:         controller-revision-hash=2365252986
                name=add-static-route
                pod-template-generation=1
Annotations:    kubernetes.io/psp=***********
Status:         Running
IP:             xx.xx.xx.xx
Controlled By:  DaemonSet/add-static-route
Containers:
  add-static-route:
    Container ID:  docker://342222c3d0e20b78ead92389c333563470dacc72347eb0381ff7a8b3f4586d55
    Image:         ibmcase/kubectl
    Image ID:      docker-pullable://ibmcase/kubectl@sha256:edcff83cbd9b495bfe177ac87efe8033cde7dd681c50064c9b33a21019281d21
    Port:          <none>
    Command:
      /bin/sh
      -c
    Args:
      _gateway=`ip route get 10.0.0.0/8 | sed 's/.*via \(.*\) dev.*/\1/'`; touch routes_${_lastVersion}.txt; while true; do
  _currVersion=`kubectl get configmap static-routes -o go-template --template '{{.metadata.resourceVersion}}'`
  if [ "${_lastVersion}" == "${_currVersion}" ]; then
    _lastVersion=${_currVersion};
    sleep 5;
    continue;
  fi;
  echo "Change detected to configmap (lastVersion=${_lastVersion}, currVersion=${_currVersion})!";
  kubectl get configmap static-routes -o go-template --template '{{.data.routes}}' | jq -r 'join("\n")' | sort | uniq > routes_${_currVersion}.txt;
  for _route in `comm -23 routes_${_lastVersion}.txt routes_${_currVersion}.txt`; do
    [ ! -z "`ip route show | grep ${_route} | grep ${_gateway}`" ] || continue;
    echo "Deleting ${_route} via ${_gateway} ...";
    ip route del ${_route} via ${_gateway};
  done;
  for _route in `comm -1 routes_${_lastVersion}.txt routes_${_currVersion}.txt | awk '{print $1;}'`; do
    [ -z "`ip route show | grep ${_route} | grep ${_gateway}`" ] || continue;
    echo "Adding ${_route} via ${_gateway} ...";
    ip route add ${_route} via ${_gateway};
  done;

  rm -f routes_${_lastVersion}.txt;
  _lastVersion=${_currVersion};
done

    State:          Running
      Started:      Mon, 09 Jul 2018 17:22:34 +0530
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from add-static-routes-token-fg2ww (ro)
Conditions:
  Type           Status
  Initialized    True 
  Ready          True 
  PodScheduled   True 
Volumes:
  add-static-routes-token-fg2ww:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  add-static-routes-token-fg2ww
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/disk-pressure:NoSchedule
                 node.kubernetes.io/memory-pressure:NoSchedule
                 node.kubernetes.io/not-ready:NoExecute
                 node.kubernetes.io/unreachable:NoExecute
Events:
  Type    Reason                 Age   From                    Message
  ----    ------                 ----  ----                    -------
  Normal  SuccessfulMountVolume  15m   kubelet, xx.xx.xx.xx  MountVolume.SetUp succeeded for volume "add-static-routes-token-fg2ww"
  Normal  Pulling                15m   kubelet, xx.xx.xx.xx  pulling image "ibmcase/kubectl"
  Normal  Pulled                 15m   kubelet, xx.xx.xx.xx  Successfully pulled image "ibmcase/kubectl"
  Normal  Created                15m   kubelet, xx.xx.xx.xx  Created container
  Normal  Started                15m   kubelet, xx.xx.xx.xx  Started container
```