### PR TITLE
Adding error checking for calls getting configmap

### DIFF
--- a/add-static-route-daemonset.yaml
+++ b/add-static-route-daemonset.yaml
@@ -24,6 +24,11 @@ spec:
               while true;
               do
                 _currVersion=`kubectl get configmap static-routes -o go-template --template '{{.metadata.resourceVersion}}'`
+                if [ $? -ne 0 ]; then
+                  echo "Error getting configmap version, taking no action";
+                  sleep 15;
+                  continue;
+                fi;
                 if [ "${_lastVersion}" == "${_currVersion}" ]; then
                   _lastVersion=${_currVersion};
                   sleep 5;
@@ -31,6 +36,11 @@ spec:
                 fi;
                 echo "Change detected to configmap (lastVersion=${_lastVersion}, currVersion=${_currVersion})!";
                 kubectl get configmap static-routes -o go-template --template '{{.data.routes}}' | jq -r 'join("\n")' | sort | uniq > routes_${_currVersion}.txt;
+                if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+                  echo "Error getting configmap contents, taking no action";
+                  sleep 5;
+                  continue;
+                fi;
                 for _route in `comm -23 routes_${_lastVersion}.txt routes_${_currVersion}.txt`; do
                   [ ! -z "`ip route show | grep ${_route} | grep ${_gateway}`" ] || continue;
                   echo "Deleting ${_route} via ${_gateway} ...";


### PR DESCRIPTION
If there is connectivity issues, kubectl get configmap calls could fail, and routes will be assumed to be the empty (deleting existing routes).  If the connectivity issues are intermittent, this could result in an empty set of routes being recorded under the correct version of the configmap (as opposed to a blank version) which will prevent the daemonset from recovering on its own.

Checking the return code on each call to get configmap information will prevent these problems.