### PR TITLE
removed extensions/v1beta1 as Daemonsets have been migrated to apps/v1

### DIFF
--- a/add-static-route-daemonset.yaml
+++ b/add-static-route-daemonset.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: add-static-route
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      name: add-static-route
   template:
     metadata:
       name: add-static-route


### PR DESCRIPTION
The current YAML doesn't work on Kubernetes v1.16 due to Daemonsets being migrated to apps/v1.  Changed to the API and added required selector name in order for YAML to create successfully.